### PR TITLE
Add support for Windows on Arm

### DIFF
--- a/.github/workflows/libclang-windows-aarch64.yml
+++ b/.github/workflows/libclang-windows-aarch64.yml
@@ -1,0 +1,66 @@
+name: libclang-windows-aarch64
+
+on: [push, pull_request]
+
+env:
+  LLVM_VER: 13.0.0
+
+jobs:
+  build-and-deploy:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: get llvm-project
+      run: |
+        choco install wget git
+        git clone https://github.com/llvm/llvm-project.git llvm-project-$env:LLVM_VER -b llvmorg-$env:LLVM_VER --depth=1
+    - name: build host llvm-tblgen/clang-tblgen
+      run: |
+        mkdir llvm-project-$env:LLVM_VER/build-host
+        cd llvm-project-$env:LLVM_VER/build-host
+        cmake ../llvm `
+          -Thost=x64 `
+          -DLLVM_ENABLE_PROJECTS=clang `
+          -DBUILD_SHARED_LIBS=OFF `
+          -DLLVM_ENABLE_TERMINFO=OFF `
+          -DLLVM_TARGETS_TO_BUILD=X86 `
+          -DCMAKE_BUILD_TYPE=MinSizeRel `
+          -DCMAKE_CXX_FLAGS="/MP" `
+          -DLLVM_USE_CRT_MINSIZEREL="MT"
+        cmake --build . --config MinSizeRel --target clang-tblgen
+        cmake --build . --config MinSizeRel --target llvm-tblgen
+        cd MinSizeRel
+        mkdir C:\llvm
+        cp bin\clang-tblgen.exe C:\llvm
+        cp bin\llvm-tblgen.exe C:\llvm
+    - name: cmake
+      run: |
+        mkdir -p llvm-project-$env:LLVM_VER/build
+        cd llvm-project-$env:LLVM_VER/build
+        cmake ../llvm `
+            -A ARM64 `
+            -Thost=x64 `
+            -DLLVM_ENABLE_PROJECTS=clang `
+            -DBUILD_SHARED_LIBS=OFF `
+            -DLLVM_ENABLE_TERMINFO=OFF `
+            -DLLVM_TARGETS_TO_BUILD=AArch64 `
+            -DLLVM_TABLEGEN=C:\llvm\llvm-tblgen.exe `
+            -DCLANG_TABLEGEN=C:\llvm\clang-tblgen.exe `
+            -DCMAKE_CXX_FLAGS="/MP" `
+            -DLLVM_USE_CRT_MINSIZEREL="MT"
+    - name: build
+      run: cd llvm-project-$env:LLVM_VER/build && cmake --build . --config MinSizeRel --target libclang
+    - name: create and print sha512sum
+      run: |
+        $env:Path = "C:\Program Files\Git\usr\bin;$env:Path"
+        cd llvm-project-$env:LLVM_VER\build\MinSizeRel\bin
+        sha512sum.exe libclang.dll > libclang.dll.$env:LLVM_VER.windows-aarch64.sha512sum
+        echo "Checksum is: "
+        Get-Content -Path libclang.dll.$env:LLVM_VER.windows-aarch64.sha512sum
+        tar zcvf libclang.dll.$env:LLVM_VER.windows-aarch64.tar.gz libclang.dll libclang.dll.$env:LLVM_VER.windows-aarch64.sha512sum
+        sha512sum.exe libclang.dll.$env:LLVM_VER.windows-aarch64.tar.gz
+    - uses: actions/upload-artifact@v2
+      with:
+        name: libclang.dll.${{env.LLVM_VER}}.windows-aarch64.tar.gz
+        path: llvm-project-${{env.LLVM_VER}}\build\MinSizeRel\bin\libclang.dll.${{env.LLVM_VER}}.windows-aarch64.tar.gz

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ libclang-for-pip
 [![Arch: arm](https://img.shields.io/badge/arch-arm-orange)](https://pypi.org/project/libclang/#files)
 
 [![Windows](https://github.com/sighingnow/libclang/workflows/libclang-windows-amd64/badge.svg)](https://github.com/sighingnow/libclang/actions/workflows/libclang-windows-amd64.yml)
+[![Windows AArch64](https://github.com/sighingnow/libclang/workflows/libclang-windows-aarch64/badge.svg)](https://github.com/sighingnow/libclang/actions/workflows/libclang-windows-aarch64.yml)
 [![Linux](https://github.com/sighingnow/libclang/workflows/libclang-linux-amd64/badge.svg)](https://github.com/sighingnow/libclang/actions/workflows/libclang-linux-amd64.yml)
 [![MacOS](https://github.com/sighingnow/libclang/workflows/libclang-macosx-amd64/badge.svg)](https://github.com/sighingnow/libclang/actions/workflows/libclang-macosx-amd64.yml)
 [![Linux Arm](https://github.com/sighingnow/libclang/workflows/libclang-linux-arm/badge.svg)](https://github.com/sighingnow/libclang/actions/workflows/libclang-linux-arm.yml)


### PR DESCRIPTION
Hi **libclang**!

This PR adds support for WoA (windows on arm - aarch64) by providing a workflow for github actions.

The ultimate goal is to be able to run `pip install libclang` directly from a WoA machine.

---

Tested with (on WoA machine):

```
# 1. create wheel manually
python setup.py bdist_wheel --plat-name=win_arm64
# 2. install it
python -m pip install .\libclang-13.0.0-py2.py3-none-win_arm64.whl
# 3. Run tests from clang official bindings
git clone https://github.com/llvm-mirror/clang/ --depth=1
cd clang\bindings\python
$env:CLANG_LIBRARY_PATH="C:\wenv\arm64\python\tools\Lib\site-packages\clang\native\" python -m unittest
...
# 2 failures reported (same as x64)
```
