### PR TITLE
Build linux libs using the manylinux2010 container.

### DIFF
--- a/.github/script-to-build-manylinux2010.sh
+++ b/.github/script-to-build-manylinux2010.sh
@@ -2,8 +2,8 @@
 
 set -x
 
-sudo docker run --privileged --network=host --rm -v `pwd`:/work frolvlad/alpine-gxx \
-            sh -c 'apk add python3 cmake make && \
+sudo docker run --privileged --network=host --rm -v `pwd`:/work quay.io/pypa/manylinux2010_x86_64:latest \
+            sh -c 'export PATH=$PATH:/opt/python/cp39-cp39/bin && \
                    mkdir -p /work/build && \
                    cd /work/build && \
                    cmake ../llvm -DLLVM_ENABLE_PROJECTS=clang -DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os -DNDEBUG -static-libgcc -static-libstdc++ -s" && \

--- a/.github/workflows/libclang-linux-amd64.yml
+++ b/.github/workflows/libclang-linux-amd64.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-and-deploy:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v3
@@ -28,20 +28,14 @@ jobs:
         mv llvm-project-$LLVM_VER.src llvm-project-$LLVM_VER
     - name: make build directory
       run: mkdir -p llvm-project-$LLVM_VER/build
-    - name: cmake
+    - name: pull docker
       run: |
-        cd llvm-project-$LLVM_VER/build
-        cmake ../llvm \
-          -DLLVM_ENABLE_PROJECTS=clang \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DLLVM_ENABLE_TERMINFO=OFF \
-          -DLLVM_TARGETS_TO_BUILD=X86 \
-          -DCMAKE_BUILD_TYPE=MinSizeRel \
-          -DCMAKE_CXX_FLAGS_MINSIZEREL="-Os -DNDEBUG -static-libgcc -static-libstdc++ -s" \
-          -DCMAKE_C_COMPILER=gcc-7 \
-          -DCMAKE_CXX_COMPILER=g++-7
-    - name: build
-      run: cd llvm-project-$LLVM_VER/build && make libclang -j$(nproc)
+        sudo docker pull quay.io/pypa/manylinux2010_x86_64:latest
+    - name: cmake & build in docker
+      run: |
+        cp .github/script-to-build-manylinux2010.sh ./llvm-project-$LLVM_VER/
+        cd llvm-project-$LLVM_VER
+        bash ./script-to-build-manylinux2010.sh
     - name: print dependencies
       run: |
         file llvm-project-$LLVM_VER/build/lib/libclang.so

--- a/.github/workflows/libclang-windows-aarch64.yml
+++ b/.github/workflows/libclang-windows-aarch64.yml
@@ -51,6 +51,7 @@ jobs:
         cmake ../llvm `
             -A ARM64 `
             -Thost=x64 `
+            -DCMAKE_SYSTEM_NAME=Windows `
             -DLLVM_ENABLE_PROJECTS=clang `
             -DBUILD_SHARED_LIBS=OFF `
             -DLLVM_ENABLE_TERMINFO=OFF `


### PR DESCRIPTION
Build the linux libs for x86_64 using the manylinux2010 container to archive better backwards compatibility.

Resolves #30.