### PR TITLE
recipe to cross-compile libclang for arm64 on macos-latest runner

### DIFF
--- a/.github/workflows/libclang-macosx-arm64.yml
+++ b/.github/workflows/libclang-macosx-arm64.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   LLVM_VER: 16.0.4
-  BIN: $BIN
+  BIN: /usr/local/opt/llvm/bin
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -22,9 +22,8 @@ jobs:
     - name: install wheel dependencies
       run: |
         pip3 install wheel
-    - name: install gnu-tar and llvm
+    - name: install llvm
       run: |
-        brew install gnu-tar
         brew install llvm  # assume install under /usr/local/opt/llvm
     - name: get llvm-project
       run: |
@@ -34,6 +33,9 @@ jobs:
     - name: cmake
       # see https://llvm.org/docs/HowToCrossCompileLLVM.html
       run: |
+        echo "BIN=$BIN" >> "$GITHUB_ENV"
+        echo "$BIN" >> "$GITHUB_PATH"
+        set echo
         uname -a
         cd llvm-project-$LLVM_VER 
         cmake -S llvm \

--- a/.github/workflows/libclang-macosx-arm64.yml
+++ b/.github/workflows/libclang-macosx-arm64.yml
@@ -1,0 +1,111 @@
+name: libclang-macosx-arm64
+
+on: [push, pull_request]
+
+env:
+  LLVM_VER: 16.0.4
+  BIN: $BIN
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: install wheel dependencies
+      run: |
+        pip3 install wheel
+    - name: install gnu-tar and llvm
+      run: |
+        brew install gnu-tar
+        brew install llvm  # assume install under /usr/local/opt/llvm
+    - name: get llvm-project
+      run: |
+        wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VER/llvm-project-$LLVM_VER.src.tar.xz
+        tar xf llvm-project-$LLVM_VER.src.tar.xz
+        mv llvm-project-$LLVM_VER.src llvm-project-$LLVM_VER
+    - name: cmake
+      # see https://llvm.org/docs/HowToCrossCompileLLVM.html
+      run: |
+        uname -a
+        cd llvm-project-$LLVM_VER 
+        cmake -S llvm \
+          -G "Unix Makefiles" -B build \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_COMPILER=$BIN/clang++ \
+          -DCMAKE_C_COMPILER=$BIN/clang \
+          -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+          -DCMAKE_OSX_ARCHITECTURES=arm64 \
+          -DCMAKE_SYSTEM_NAME=Darwin \
+          -DDEFAULT_SYSROOT="$(xcrun --show-sdk-path)" \
+          -DLLVM_DEFAULT_TARGET_TRIPLE=16.0.4-arm64-apple-darwin21.6 \
+          -DLLVM_ENABLE_PIC=False \
+          -DLLVM_ENABLE_PROJECTS=clang \
+          -DLLVM_ENABLE_TERMINFO=OFF \
+          -DLLVM_ENABLE_WERROR=FALSE \
+          -DLLVM_ENABLE_ZLIB=OFF \
+          -DLLVM_ENABLE_ZSTD=OFF \
+          -DLLVM_NATIVE_TOOL_DIR=$BIN \
+          -DLLVM_USE_LINKER=lld \
+          -DLLVM_TARGETS_TO_BUILD=AArch64
+    - name: build
+      run: |
+        cd llvm-project-$LLVM_VER 
+        cmake --build build --config Release --target libclang --parallel $(sysctl -n hw.ncpu)
+    - name: combine .a archives into dylib
+      run: |
+        cd llvm-project-$LLVM_VER/build/lib
+        set echo
+        # convert .a -> dylib
+        $BIN/clang -arch arm64 -fpic -shared  -lstdc++ -Wl,-force_load libclang.a *.a -o libclang.dylib
+        strip -u libclang.dylib
+        lipo -info libclang.dylib
+        du -csh libclang.dylib
+        file libclang.dylib
+        otool -L libclang.dylib
+        dyld_info -platform -dependents libclang.dylib 
+    - name: create and print sha512sum
+      run: |
+        cd llvm-project-$LLVM_VER/build/lib
+        shasum -a512 libclang.dylib > libclang.dylib.$LLVM_VER.macosx-arm64.sha512sum
+        echo "Checksum is: "
+        cat libclang.dylib.$LLVM_VER.macosx-arm64.sha512sum
+        gtar zcvf libclang.dylib.$LLVM_VER.macosx-arm64.tar.gz libclang.dylib libclang.dylib.$LLVM_VER.macosx-arm64.sha512sum
+        shasum -a512 libclang.dylib.$LLVM_VER.macosx-arm64.tar.gz
+    - uses: actions/upload-artifact@v3
+      with:
+        name: libclang.dylib.${{env.LLVM_VER}}.macosx-arm64.tar.gz
+        path: llvm-project-${{env.LLVM_VER}}/build/lib/libclang.dylib.${{env.LLVM_VER}}.macosx-arm64.tar.gz
+    - name: generate wheel package
+      run: |
+        cp llvm-project-$LLVM_VER/build/lib/libclang.dylib native/
+        python3 setup_ext.py bdist_wheel --universal --plat-name=macosx_21.6_arm64
+    - uses: actions/upload-artifact@v3
+      with:
+        name: wheel-${{env.LLVM_VER}}-macosx_21.6_arm64
+        path: dist/*.whl
+
+  upload-to-pypi:
+    runs-on: ubuntu-latest
+    needs: [build-and-deploy]
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: wheel-${{env.LLVM_VER}}-macosx_21.6_arm64
+        path: dist/
+    - name: Publish to PyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages_dir: dist/
+        password: ${{ secrets.PYPI_TOKEN }}
+        verbose: true
+        print_hash: true


### PR DESCRIPTION
tested on x86_64 default github runner to produce an arm64 compatible libclang.dylib
cmake with BUILD_SHARED_LIBS=ON builds a libclang.dylib with dependents, so the workaround here is to build .a archives and then assemble them into a single dylib.

see artifacts and log at:
https://github.com/d-e-e-p/libclang/actions/runs/5095230952