### PR TITLE
Fix bdist_wheel import errors

### DIFF
--- a/.github/workflows/libclang-alpine-amd64.yml
+++ b/.github/workflows/libclang-alpine-amd64.yml
@@ -21,9 +21,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: get llvm-project
       run: |
         wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VER/llvm-project-$LLVM_VER.src.tar.xz

--- a/.github/workflows/libclang-linux-aarch64.yml
+++ b/.github/workflows/libclang-linux-aarch64.yml
@@ -21,9 +21,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: get llvm-project
       run: |
         wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VER/llvm-project-$LLVM_VER.src.tar.xz

--- a/.github/workflows/libclang-linux-amd64.yml
+++ b/.github/workflows/libclang-linux-amd64.yml
@@ -21,9 +21,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: get llvm-project
       run: |
         wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VER/llvm-project-$LLVM_VER.src.tar.xz

--- a/.github/workflows/libclang-linux-arm.yml
+++ b/.github/workflows/libclang-linux-arm.yml
@@ -21,9 +21,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: get llvm-project
       run: |
         wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VER/llvm-project-$LLVM_VER.src.tar.xz

--- a/.github/workflows/libclang-macosx-amd64.yml
+++ b/.github/workflows/libclang-macosx-amd64.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: install gnu-tar
       run: |
         brew install gnu-tar

--- a/.github/workflows/libclang-macosx-arm64.yml
+++ b/.github/workflows/libclang-macosx-arm64.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: install gnu-tar
       run: |
         brew install gnu-tar

--- a/.github/workflows/libclang-windows-aarch64.yml
+++ b/.github/workflows/libclang-windows-aarch64.yml
@@ -18,9 +18,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: get llvm-project
       run: |
         choco install wget git

--- a/.github/workflows/libclang-windows-amd64.yml
+++ b/.github/workflows/libclang-windows-amd64.yml
@@ -18,9 +18,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: install wheel dependencies
+    - name: install setuptools dependencies
       run: |
-        pip3 install wheel
+        pip3 install -U setuptools==75.8.0
     - name: get llvm-project
       run: |
         choco install wget git

--- a/setup_ext.py
+++ b/setup_ext.py
@@ -7,7 +7,7 @@ from distutils.command.build import build
 from distutils.dir_util import mkpath
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
-from wheel.bdist_wheel import get_platform, bdist_wheel
+from setuptools.command.bdist_wheel import get_platform, bdist_wheel
 
 
 def platform_ext(plat):


### PR DESCRIPTION
The bdist_wheel function were moved from the `wheel` PyPI package to `setuptools`. This PR updates the setup_ext.py build script to import from the new location, and updates the workflows to ensure that a new enough version of setuptools is installed to have the moved functions (some of the GitHub Actions runner VMs have an older version of setuptools that does not yet have the imported functions).

All of the wheel builds seem to pass after this change, except for the x86_64 macOS build. Here are the build results from my latest test run:
* macOS arm64 - https://github.com/nightlark/libclang/actions/runs/13122912550
* Linux AMD64 - https://github.com/nightlark/libclang/actions/runs/13122912525
* Linux aarch64 - https://github.com/nightlark/libclang/actions/runs/13122912548
* Linux arm - https://github.com/nightlark/libclang/actions/runs/13122912519
* Alpine (musl) AMD64 - https://github.com/nightlark/libclang/actions/runs/13122912520
* Windows AMD64 - https://github.com/nightlark/libclang/actions/runs/13122912536
* Windows aarch64 - https://github.com/nightlark/libclang/actions/runs/13122912538

For macOS amd64, things I've tried that failed (after updating the runner label from macos-11 to macos-14 and adding the option -DCMAKE_OSX_ARCHITECTURES=x86_64 to make the compiler build for x86_64 instead of arm64):
* Using gcc-14 compiler - fails because the gcc installed can't compile for an x86_64 target
* Using default AppleClang compiler - fails because it can't link with lib atomic (not sure what's up with this one...)
* Using LLVM-15 clang compiler from Homebrew - fails to find x86_64 version of compiled symbols in libstdc++

It's kinda odd that using the default AppleClang compiler has a lib atomic CMake check fail -- PR #78 using cibuildwheel and scikit-build-core driving the build results in a x86_64 libclang.dylib file, and it is using the default AppleClang compiler.